### PR TITLE
Added condition to raise error if not all records assemble.

### DIFF
--- a/synbio/assembly/clone.py
+++ b/synbio/assembly/clone.py
@@ -108,6 +108,8 @@ def clone_many_combinatorial(
         include: List of strings to filter assemblies against
         min_count: The mininum number of SeqRecords for an assembly to be considered
         linear: Whether the individual SeqRecords are assumed to be linear
+        stop_condition: Whether an error should be raised if an input SeqRecord is missing from
+        the final assembly
 
     Returns:
         List[Tuple[List[SeqRecord], List[SeqRecord]]] -- list of tuples with:
@@ -153,6 +155,8 @@ def clone_combinatorial(
         include: the include to filter assemblies
         min_count: mininum number of SeqRecords for an assembly to be considered
         linear: Whether the individual SeqRecords are assumed to be linear
+        stop_condition: Whether an error should be raised if an input SeqRecord is missing from
+        the final assembly
 
     Returns:
         A list of tuples with:

--- a/synbio/protocols/clone.py
+++ b/synbio/protocols/clone.py
@@ -50,6 +50,7 @@ class Clone(Protocol):
         include: List[str] = None,
         min_count: int = -1,
         separate_reagents: bool = False,
+        stop_condition: bool = False
     ):
         super().__init__(name=name, design=design, separate_reagents=separate_reagents)
 
@@ -58,6 +59,7 @@ class Clone(Protocol):
         self.mix = mix
         self.min_count = min_count
         self.wells_to_construct: Dict[Container, Container] = {}
+        self.stop_condition = stop_condition
 
     def run(self):
         """Filter designs to those that will form valid and new plasmids.
@@ -108,6 +110,7 @@ class Clone(Protocol):
             include=self.include,
             min_count=self.min_count,
             linear=self.design.linear,
+            stop_condition=self.stop_condition
         ):
             # add reaction mix and water
             well_contents, well_volumes = self.mix(fragments + self.enzymes)

--- a/synbio/protocols/clone.py
+++ b/synbio/protocols/clone.py
@@ -39,6 +39,8 @@ class Clone(Protocol):
         mix: the assembly mix to use when mixing the assemblies with enzymes
         min_count: the minimum number of SeqRecords in an assembly for it to
             be considered valid. smaller assemblies are ignored
+        stop_condition: Whether an error should be raised if an input SeqRecord is missing from
+        the final assembly
     """
 
     def __init__(


### PR DESCRIPTION
I ran into a use-case while utilizing this library where a construct will assemble without containing all of the records that are specified in the input. In the cases where one cares about having all records present in the assembly, I added a `stop_condition` parameter to the clone protocol that when set to `True`, raises an exception if a record that is given as input is missing from the final plasmid assembly.