### PR TITLE
Use older version of biopython.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-biopython>=1.74.0
+biopython==1.7.7
 networkx>=2.3.0
 fuzzywuzzy
 primers>=0.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-biopython==1.7.7
+biopython==1.77
 networkx>=2.3.0
 fuzzywuzzy
 primers>=0.2.4

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("requirements.txt") as f:
 setup(
     name="synbio",
     version="0.6.17",
-    python_requires=">=3",
+    python_requires=">=3,<3.12",
     author="JJTimmons",
     author_email="jtimmons@latticeautomation.com",
     url="https://github.com/Lattice-Automation/synbio",


### PR DESCRIPTION
`biopython` versions newer than `1.7.7` seem to cause the following error with the synbio library: 

"ImportError: Bio.Alphabet has been removed from Biopython. In many cases, the alphabet can simply be ignored and removed from scripts. In a few cases, you may need to specify the ``molecule_type`` as an annotation on a SeqRecord for your script to work correctly. Please see https://biopython.org/wiki/Alphabet for more information."

In the future the code should be refactored to remove using `Bio.Alphabet` although for now I'm fixing the biopython version to get things back to working order.